### PR TITLE
Use ipinfo.io/json as public ip backend

### DIFF
--- a/public-ip.go
+++ b/public-ip.go
@@ -7,6 +7,8 @@ import (
 	"os"
 )
 
+// IpInfo is the information one gets by their service as json
+// Generated with http://json2struct.mervine.net
 type IpInfo struct {
 	City     string `json:"city"`
 	Country  string `json:"country"`

--- a/public-ip.go
+++ b/public-ip.go
@@ -1,37 +1,54 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
-	"os"
-	"strings"
-
-	"io/ioutil"
 	"net/http"
+	"os"
 )
 
+type IpInfo struct {
+	City     string `json:"city"`
+	Country  string `json:"country"`
+	Hostname string `json:"hostname"`
+	IP       string `json:"ip"`
+	Loc      string `json:"loc"`
+	Org      string `json:"org"`
+	Postal   string `json:"postal"`
+	Region   string `json:"region"`
+}
+
 func main() {
-
-	// Set display texts to defaults.
-	var fullText string = "unknown"
-	var shortText string = "unknown"
-
 	// Request whats-my-ip service to return this
 	// machine's public IP address via TLS.
-	resp, _ := http.Get("https://ip.wirelab.org/")
+	resp, err := http.Get("http://ipinfo.io/json")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
 
-	// Read-in body part of response containing
-	// the raw IP address.
-	ipRaw, _ := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		fmt.Fprintf(os.Stderr, "server returned %s not 200 OK", resp.Status)
+		os.Exit(1)
+	}
 
-	// Remove surrounding space.
-	ip := strings.TrimSpace(string(ipRaw))
+	var info IpInfo
+	dec := json.NewDecoder(resp.Body)
+	if err := dec.Decode(&info); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to decode json: %v", err)
+		os.Exit(2)
+	}
+
+	// Set display texts to defaults.
+	fullText := "unknown"
+	shortText := "unknown"
 
 	// If response indeed contained an IP address,
 	// set i3bar protocols fields accordingly.
-	if ip != "" {
-		fullText = ip
-		shortText = ip
+	if info.IP != "" {
+		fullText = info.IP
+		shortText = info.IP
 	}
 
 	// Write out gathered information to STDOUT.


### PR DESCRIPTION
Use ipinfo.io as backend. They provide a lot more information. And I would be interested in showing the current public IP's country, which is handy when using a VPN.