### PR TITLE
Fix public IP and internal IP on devices with more than one network interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Reload i3 and enjoy beautiful blocklets.
 **public-ip**: Queries [ifconfig.co/ip](https://ifconfig.co/ip) in defined interval to determine your public IP address.
 
 **internal-ip**: Displays the first found IP address associated with the first network interface marked as being active and not the loopback interface of your machine.
+It is possible to specify an interface name to use by passing an argument. `-ifaceName wlp2s0` Look up interface names by running `ip addr show`
 
 **uptime**: By default, shows your machine's uptime in format `hh:mm`. If you would like to see the seconds value as well, change the `command` value of blocklet `uptime` to `command=~/.config/i3blocks-go/uptime -showSeconds`. Consults your system's `/proc/uptime` file.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Reload i3 and enjoy beautiful blocklets.
 
 ## Blocklet Specifics
 
-**public-ip**: Queries [ip.wirelab.org](https://ip.wirelab.org/) in defined interval to determine your public IP address.
+**public-ip**: Queries [ifconfig.co/ip](https://ifconfig.co/ip) in defined interval to determine your public IP address.
 
 **internal-ip**: Displays the first found IP address associated with the first network interface marked as being active and not the loopback interface of your machine.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Reload i3 and enjoy beautiful blocklets.
 
 ## Blocklet Specifics
 
-**public-ip**: Queries [ifconfig.co/ip](https://ifconfig.co/ip) in defined interval to determine your public IP address.
+**public-ip**: Queries [ifconfig.co/ip](https://ifconfig.co/ip) in defined interval to determine your public IP address. Pass `-city` flag to get name of the city instead of IP
 
 **internal-ip**: Displays the first found IP address associated with the first network interface marked as being active and not the loopback interface of your machine.
 It is possible to specify an interface name to use by passing an argument. `-ifaceName wlp2s0` Look up interface names by running `ip addr show`

--- a/cmd/internal-ip/main.go
+++ b/cmd/internal-ip/main.go
@@ -17,7 +17,7 @@ func main() {
 	var iface = &net.Interface{}
 
 	// Check if interface parameter was passed in
-	var ifaceNameFlag = flag.String("ifaceName", "", "-ifaceName wlp2s0")
+	var ifaceNameFlag = flag.String("ifaceName", "", "Specify the name of the interface of which to display its IP.")
 	flag.Parse()
 
 	if ifaceNameFlag == nil || *ifaceNameFlag == "" {

--- a/cmd/internal-ip/main.go
+++ b/cmd/internal-ip/main.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 )
 
+// Set display texts to defaults.
 var fullText = "unknown"
 var shortText = "unknown"
 
 func main() {
-	// Set display texts to defaults.
 	var iface = &net.Interface{}
 
 	// Check if interface parameter was passed in
@@ -21,7 +21,7 @@ func main() {
 	flag.Parse()
 
 	if ifaceNameFlag == nil || *ifaceNameFlag == "" {
-		// ifaceName paramerer was not passed, use first interface that is up
+		// ifaceName parameter was not passed, use first interface that is up
 		desiredIface, err := firstNonLoopbackInterfaceThatIsUp()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s", err.Error())

--- a/cmd/internal-ip/main.go
+++ b/cmd/internal-ip/main.go
@@ -61,7 +61,7 @@ func firstNonLoopbackInterfaceThatIsUp() (*net.Interface, error) {
 	if err != nil {
 		// Write an error to STDERR, fallback display values
 		// to STDOUT and writeAndExit with failure code.
-		return &net.Interface{}, fmt.Errorf("[i3blocks-go] Failed to retrieve local interfaces: %s", err.Error())
+		return nil, fmt.Errorf("[i3blocks-go] Failed to retrieve local interfaces: %s", err.Error())
 	}
 
 	for _, iface := range ifaces {

--- a/cmd/internal-ip/main.go
+++ b/cmd/internal-ip/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"net"

--- a/cmd/internal-ip/main.go
+++ b/cmd/internal-ip/main.go
@@ -20,7 +20,7 @@ func main() {
 	var ifaceNameFlag = flag.String("ifaceName", "", "Specify the name of the interface of which to display its IP.")
 	flag.Parse()
 
-	if ifaceNameFlag == nil || *ifaceNameFlag == "" {
+	if *ifaceNameFlag == "" {
 		// ifaceName parameter was not passed, use first interface that is up
 		desiredIface, err := firstNonLoopbackInterfaceThatIsUp()
 		if err != nil {

--- a/cmd/internal-ip/main.go
+++ b/cmd/internal-ip/main.go
@@ -77,7 +77,7 @@ func firstNonLoopbackInterfaceThatIsUp() (*net.Interface, error) {
 		}
 		return &iface, nil
 	}
-	return &net.Interface{}, errors.New("non loopback interface that is up not found")
+	return &net.Interface{}, fmt.Errorf("[i3blocks-go] Could not find non-loopback interface that is up")
 }
 
 // Write out gathered information to STDOUT.

--- a/cmd/internal-ip/main.go
+++ b/cmd/internal-ip/main.go
@@ -1,63 +1,87 @@
 package main
 
 import (
+	"errors"
+	"flag"
 	"fmt"
 	"net"
 	"os"
 	"strings"
 )
 
+var fullText = "unknown"
+var shortText = "unknown"
+
 func main() {
-
 	// Set display texts to defaults.
-	var fullText string = "unknown"
-	var shortText string = "unknown"
+	var iface = &net.Interface{}
 
+	// Check if interface parameter was passed in
+	var ifaceNameFlag = flag.String("ifaceName", "", "-ifaceName wlp2s0")
+	flag.Parse()
+
+	if ifaceNameFlag == nil || *ifaceNameFlag == "" {
+		// ifaceName paramerer was not passed, use first interface that is up
+		desiredIface, err := firstNonLoopbackInterfaceThatIsUp()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s", err.Error())
+			writeAndExit()
+		}
+		iface = desiredIface
+	} else {
+		// ifaceName was passed, use the name to get interface
+		desiredIface, err := net.InterfaceByName(*ifaceNameFlag)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[i3blocks-go] Failed to find interface with name %s. %s", *ifaceNameFlag, err.Error())
+			writeAndExit()
+		}
+		iface = desiredIface
+	}
+
+	// Retrieve all addresses belonging to
+	// found active interface.
+	addrs, err := iface.Addrs()
+	if err != nil || len(addrs) == 0 {
+		fmt.Fprintf(os.Stderr, "[i3blocks-go] Failed to retrieve IP addresses associated with %s: %v", iface.Name, err)
+		writeAndExit()
+	}
+
+	// Extract the actual IP from address string
+	// and remove subnet information.
+	ipRaw := strings.Split(addrs[0].String(), "/")
+
+	fullText = ipRaw[0]
+	shortText = ipRaw[0]
+	writeAndExit()
+}
+
+func firstNonLoopbackInterfaceThatIsUp() (*net.Interface, error) {
 	// Get all interfaces associated with this machine.
 	ifaces, err := net.Interfaces()
 	if err != nil {
-
 		// Write an error to STDERR, fallback display values
-		// to STDOUT and exit with failure code.
-		fmt.Fprintf(os.Stderr, "[i3blocks-go] Failed to retrieve local interfaces: %s", err.Error())
-		fmt.Fprintf(os.Stdout, "%s\n%s\n", fullText, shortText)
-		os.Exit(0)
+		// to STDOUT and writeAndExit with failure code.
+		return &net.Interface{}, fmt.Errorf("[i3blocks-go] Failed to retrieve local interfaces: %s", err.Error())
 	}
 
 	for _, iface := range ifaces {
-
 		// If current interface is not marked as being
 		// active, continue to next for loop iteration.
 		if (iface.Flags & net.FlagUp) != 1 {
 			continue
 		}
-
 		// If this interface is the machine's loopback
 		// interface, continue to next for loop iteration.
 		if (iface.Flags & net.FlagLoopback) == 4 {
 			continue
 		}
-
-		// Retrieve all addresses belonging to
-		// found active interface.
-		addrs, err := iface.Addrs()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "[i3blocks-go] Failed to retrieve IP addresses associated with %s: %s", iface.Name, err.Error())
-			fmt.Fprintf(os.Stdout, "%s\n%s\n", fullText, shortText)
-			os.Exit(0)
-		}
-
-		// Extract the actual IP from address string
-		// and remove subnet information.
-		ipRaw := strings.Split(addrs[0].String(), "/")
-
-		fullText = ipRaw[0]
-		shortText = ipRaw[0]
-
-		break
+		return &iface, nil
 	}
+	return &net.Interface{}, errors.New("non loopback interface that is up not found")
+}
 
-	// Write out gathered information to STDOUT.
+// Write out gathered information to STDOUT.
+func writeAndExit() {
 	fmt.Fprintf(os.Stdout, "%s\n%s\n", fullText, shortText)
 	os.Exit(0)
 }

--- a/cmd/public-ip/main.go
+++ b/cmd/public-ip/main.go
@@ -23,7 +23,7 @@ func main() {
 	var cityFlag = flag.Bool("city", false, "Pass -city to report city instead of IP.")
 	flag.Parse()
 
-	if cityFlag != nil && *cityFlag {
+	if *cityFlag {
 		whatIsMyIpUrl = urlForCity
 	} else {
 		whatIsMyIpUrl = urlForIp

--- a/cmd/public-ip/main.go
+++ b/cmd/public-ip/main.go
@@ -17,7 +17,7 @@ func main() {
 
 	// Request whats-my-ip service to return this
 	// machine's public IP address via TLS.
-	resp, err := http.Get("https://ip.wirelab.org/")
+	resp, err := http.Get("https://ifconfig.co/ip")
 	if err != nil {
 
 		// Write an error to STDERR, fallback display values

--- a/cmd/public-ip/main.go
+++ b/cmd/public-ip/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -10,14 +11,27 @@ import (
 )
 
 func main() {
+	// Url to get IP info
+	var urlForIp string = "https://ifconfig.co/ip"
+	var urlForCity string = "https://ifconfig.co/city"
 
 	// Set display texts to defaults.
 	var fullText string = "unknown"
 	var shortText string = "unknown"
+	var whatIsMyIpUrl string
+
+	var cityFlag = flag.Bool("city", false, "pass -city to report City instead of IP")
+	flag.Parse()
+
+	if cityFlag != nil && *cityFlag {
+		whatIsMyIpUrl = urlForCity
+	} else {
+		whatIsMyIpUrl = urlForIp
+	}
 
 	// Request whats-my-ip service to return this
 	// machine's public IP address via TLS.
-	resp, err := http.Get("https://ifconfig.co/ip")
+	resp, err := http.Get(whatIsMyIpUrl)
 	if err != nil {
 
 		// Write an error to STDERR, fallback display values

--- a/cmd/public-ip/main.go
+++ b/cmd/public-ip/main.go
@@ -20,7 +20,7 @@ func main() {
 	var shortText string = "unknown"
 	var whatIsMyIpUrl string
 
-	var cityFlag = flag.Bool("city", false, "pass -city to report City instead of IP")
+	var cityFlag = flag.Bool("city", false, "Pass -city to report city instead of IP.")
 	flag.Parse()
 
 	if cityFlag != nil && *cityFlag {

--- a/example-i3blocks.conf
+++ b/example-i3blocks.conf
@@ -10,13 +10,13 @@ separator_block_width=18
 markup=none
 
 
-# Public IP of this machine. Determined by querying https://ip.wirelab.org
-# regularly. Longer intervals useful, e.g. 60 seconds.
+# Public IP of this machine. Determined by querying https://ifconfig.co
+# regularly. Longer intervals useful, e.g. 60 seconds. To specify
+# interface to monitor, pass interface name.
+# command=~/.config/i3blocks-go/public-ip -ifaceName wlp2s0
 [public-ip]
 label=
 command=~/.config/i3blocks-go/public-ip
-# To specify interface to monitor, pass interface name
-# command=~/.config/i3blocks-go/public-ip -ifaceName wlp2s0
 interval=60
 color=#dddddd
 

--- a/example-i3blocks.conf
+++ b/example-i3blocks.conf
@@ -15,6 +15,8 @@ markup=none
 [public-ip]
 label=
 command=~/.config/i3blocks-go/public-ip
+# To specify interface to monitor, pass interface name
+# command=~/.config/i3blocks-go/public-ip -ifaceName wlp2s0
 interval=60
 color=#dddddd
 


### PR DESCRIPTION
Updated ip lookup service to ifconfig.co because the old one was not working.
Added ability to specify interface name for internal IP blocklet. Fixed issue with Internal IP blocklet panicking on laptops with enabled, but not connected ethernet.